### PR TITLE
add another incompatibility

### DIFF
--- a/docs/dbt-synapse/synapse_syntax_wishlist.md
+++ b/docs/dbt-synapse/synapse_syntax_wishlist.md
@@ -151,6 +151,9 @@ WITH dbt__CTE__INTERNAL_test AS (
 SELECT COUNT(*) FROM dbt__CTE__INTERNAL_test
 ```
 
+## 5) `sp_rename` unsupported in Synapse Serverless pools
+
+You can't rename views and external tables in Synapse serverless SQL pools. It is however, supported in dedicated SQL pools. See [MicrosoftDocs/sql-docs/pull/6793](https://github.com/MicrosoftDocs/sql-docs/pull/6793)
 # Other Differences
 
 ## 1) `tempdb.INFORMATION_SCHEMA.COLUMNS`


### PR DESCRIPTION
you can't use `sp_rename` to rename views in Synapse serverless SQL pools